### PR TITLE
fix: pin Quartz checkout to v5.0.0 to restore broken build

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@main
         with:
           repository: jackyzha0/quartz
+          ref: v5.0.0
           fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.site-config/.quartz/plugins.ts
+++ b/.site-config/.quartz/plugins.ts
@@ -1,0 +1,5 @@
+// Quartz v5 requires this module to export CustomOgImagesEmitterName.
+// MoonDAO uses a static OG image (quartz/static/og-image.png) rather than
+// a custom OG image emitter, so this exports the sentinel value and
+// no emitter will be registered under this name.
+export const CustomOgImagesEmitterName = "CustomOgImages"


### PR DESCRIPTION
## Root cause

Quartz v5 introduced a plugin system that requires a user-provided \`.quartz/plugins\` module. The framework's own \`quartz/components/Head.tsx\` statically imports from this path:

\`\`\`ts
import { CustomOgImagesEmitterName } from "../../.quartz/plugins"
\`\`\`

MoonDAO's \`.site-config/\` didn't include this file, so the build failed immediately with:

\`\`\`
✘ [ERROR] Could not resolve "../../.quartz/plugins"
\`\`\`

This was introduced between April 21 and June 8 in the upstream \`v5\` branch, and is also present in the \`v5.0.0\` tag.

## Fix (2 commits)

**1. Pin Quartz checkout to \`v5.0.0\`**  
Added \`ref: v5.0.0\` to the "Checkout Quartz" step so future upstream breaking changes don't silently break the build.

**2. Add \`.site-config/.quartz/plugins.ts\`**  
This file is rsync'd to \`.quartz/plugins.ts\` at the quartz project root during the build. It exports the \`CustomOgImagesEmitterName\` sentinel that \`Head.tsx\` expects. MoonDAO uses a static OG image (\`quartz/static/og-image.png\`) rather than a custom emitter, so this stub is all that's needed — the build falls back to the static image when no matching emitter is registered.